### PR TITLE
#3990 sftp-fs check if file obj provides seek() method

### DIFF
--- a/fs/expose/sftp.py
+++ b/fs/expose/sftp.py
@@ -236,12 +236,14 @@ class SFTPHandle(paramiko.SFTPHandle):
 
     @report_sftp_errors
     def read(self, offset, length):
-        self._file.seek(offset)
+        if hasattr(self._file, 'seek'):
+            self._file.seek(offset)
         return self._file.read(length)
 
     @report_sftp_errors
     def write(self, offset, data):
-        self._file.seek(offset)
+        if hasattr(self._file, 'seek'):
+            self._file.seek(offset)
         self._file.write(data)
         return paramiko.SFTP_OK
 


### PR DESCRIPTION
SFTP fs: avoid to use `open.seek()` method if the file-like object does not provide it (gdrivefs doesn't)
